### PR TITLE
Add a NullKernel for C_R to create an invertible matrix

### DIFF
--- a/surface_deposit_1D.i
+++ b/surface_deposit_1D.i
@@ -37,6 +37,10 @@
     type = TimeDerivative
     variable = C_O
   []
+  [C_R]
+    type = NullKernel
+    variable = C_R
+  []
 []
 
 [BCs]
@@ -78,7 +82,7 @@
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
   petsc_options = '-ksp_converged_reason -snes_converged_reason -snes_test_display'
-  solve_type = JFNK
+  solve_type = PJFNK
   num_steps = 1000
   end_time = 1.8
   dtmax = 0.5e-2


### PR DESCRIPTION
The C_R variable lives on the entire 1-D block but previously it
was only getting residual and Jacobian contributions from the NodalKernel
on the left boundary. This resulted in MOOSE/PETSc not even allocating
diagonal jacobian entries for C_R which leads to segmentation faults
or errors from preconditioners like hpyre's boomeramg. To fix this
we add a NullKernel for C_R which adds small diagonal entries for
dofs in the interior domain